### PR TITLE
Miscellaneous changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ The server accepts the following commands:
      remove   - remove a file
      rename   - rename a file
      sha1     - get sha1 sum of a file
-     list     - get dir/file info
+     list     - get file info
+
+ #### directory operations
+
+     mkdir    - create a directory on the SD card
+     rmdir    - remove a directory (has to be empty)
+     list     - get all file info in a directory
  
  #### config   - change wifi settings
  
@@ -103,6 +109,14 @@ The server accepts the following commands:
     
     curl http://sdwifi.local/rename?from=ffboot_new.bin&to=ffboot.bin
  
+   Create a directory
+    
+    curl http://sdwifi.local/mkdir?path=boot
+  
+   Remove a directory
+    
+    curl http://sdwifi.local/rmdir?path=boot
+
    Give permanent control over SD to ESP32, blocks access to NAND SD card from the host side
      
     curl http://sdwifi.local/exp?io26=esp32

--- a/pins_arduino.h
+++ b/pins_arduino.h
@@ -1,0 +1,58 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS = 5;
+static const uint8_t MOSI = 23;
+static const uint8_t MISO = 19;
+static const uint8_t SCK = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+// SDCARD Slot
+#define BOARD_HAS_SDMMC
+#define SDMMC_D2             12  // SDMMC Data2
+#define SDMMC_D3             13  // SDMMC Data3 / SPI CS
+#define SDMMC_CMD            15  // SDMMC CMD   / SPI MOSI
+#define SDMMC_CLK            14  // SDMMC CLK   / SPI SCK
+#define SDMMC_D0              2  // SDMMC Data0 / SPI MISO
+#define SDMMC_D1              4  // SDMMC Data1
+#define BOARD_MAX_SDMMC_FREQ SDMMC_FREQ_DEFAULT
+
+#endif /* Pins_Arduino_h */

--- a/sdwifi.ino
+++ b/sdwifi.ino
@@ -343,13 +343,11 @@ void handleInfo(void)
     txt += "\"status\":\"free\",";
     txt += "\"cardsize\":";
     txt += SD_MMC.cardSize();
-#if 0
-    //BUGBUG: the 1st after mount() call to f_getfree() takes about a second (?)
     txt += ",\"totalbytes\":";
     txt += SD_MMC.totalBytes();
     txt += ",\"usedbytes\":";
     txt += SD_MMC.usedBytes();
-#endif
+
     umountSD();
     break;
   case MOUNT_BUSY:

--- a/sdwifi.ino
+++ b/sdwifi.ino
@@ -152,6 +152,7 @@ void setupWiFi()
 }
 void setupWebServer()
 {
+  server.enableCORS();
   /* TODO: rethink the API to simplify scripting  */
   server.on("/ping", []()
             { httpOK(); });
@@ -178,8 +179,12 @@ void setupWebServer()
 
   /* Static content */
   server.serveStatic("/", SPIFFS, "/");
-  server.onNotFound([]()
-                    { httpNotFound(); });
+  server.onNotFound([]() {
+    switch(server.method()) {
+      case HTTP_OPTIONS: httpOK(); break;
+      default: httpNotFound(); break;
+    }
+  });
 
   log_i("HTTP server started");
 }


### PR DESCRIPTION
- I've been creating an ESP3D Extension to use the SD WIFI Pro as an offload buffer for my 3D Printer. Another ESP32 is hosting ESP3D and presents an UI to the user which contains javascript to directly upload the the SD WIFI Pro, running this project, sdwifi.
=> This is the reason why I needed to enable CORS.

- Then, from that ESP3D Extension, I needed a way to convert the long file names from the SD card to short file names (SFN) as my printer can only understand SFNs.
=> This is why I needed to add SFN in the listing of the `/list` query. It presents LFN to the user but sends SFN to the printer.

- My SD WIFI Pro has the following identification:
```
Chip is ESP32-PICO-D4 (revision v1.1)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
```
=> This is why I needed `pins_arduino.h` to override defaults' `SD_MMC.h` pins.

- I tried to enable back `usedbytes` and `totalbytes`, despite the comment saying it's laggy. I have not seen any problem with it.

Here is a screenshot of what I was able to create thanks to your firmware, thanks again!
![image](https://github.com/user-attachments/assets/efc76a0e-525d-4c37-bc3c-751440f5a050)
